### PR TITLE
Preserve collision and explosion info long enough for players receive them

### DIFF
--- a/app/src/main/java/se/cygni/paintbot/game/WorldUpdater.java
+++ b/app/src/main/java/se/cygni/paintbot/game/WorldUpdater.java
@@ -123,7 +123,7 @@ public class WorldUpdater {
             }
         }
 
-        WorldState positionUpdatedWorld = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState positionUpdatedWorld = ws.withTiles(tiles);
 
         Map<Integer, List<String>> positionsExploded = new HashMap<>();
         actions.entrySet().stream()
@@ -182,7 +182,7 @@ public class WorldUpdater {
         // Set colliding players to stunned
         stunnedPlayers.forEach(p -> nextWorld.getCharacterById(p).setIsStunnedForTicks(gameFeatures.getNoOfTicksStunned()));
 
-        WorldState explosionsHappenedWorld = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState explosionsHappenedWorld = ws.withTiles(tiles);
 
         playerManager.getLivePlayers().forEach(p -> {
             if (!gameFeatures.getPointsPerTick()) {
@@ -198,8 +198,9 @@ public class WorldUpdater {
             explosionsHappenedWorld.getCharacterById(p.getPlayerId()).setPoints(p.getTotalPoints());
         });
 
-        return new WorldState(ws.getWidth(), ws.getHeight(), tiles, nextWorld.getCollisions(), nextWorld
-                .getExplosions());
+        return ws.withTiles(tiles)
+            .withCollisions(nextWorld.getCollisions())
+            .withExplosions(nextWorld.getExplosions());
     }
 
     private void increaseStunsCaused(ConcurrentHashMap<String, Integer> stunsCaused, String playerId) {

--- a/app/src/test/java/se/cygni/paintbot/game/WorldUpdaterTest.java
+++ b/app/src/test/java/se/cygni/paintbot/game/WorldUpdaterTest.java
@@ -38,7 +38,7 @@ public class WorldUpdaterTest {
         tiles[bot1Pos] = new Tile(new CharacterImpl("A", "A", bot1Pos), "A");
         tiles[bot2Pos] = new Tile(new CharacterImpl("B", "B", bot2Pos), "B");
 
-        WorldState start = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState start = ws.withTiles(tiles);
         GameFeatures gameFeatures = new GameFeatures();
         WorldUpdater updater = createUpdater(gameFeatures, "immediateFrontalCollision");
 
@@ -89,7 +89,7 @@ public class WorldUpdaterTest {
         tiles[bot1Pos] = new Tile(new CharacterImpl("A", "A", bot1Pos), "A");
         tiles[bot2Pos] = new Tile(new CharacterImpl("B", "B", bot2Pos), "B");
 
-        WorldState start = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState start = ws.withTiles(tiles);
         GameFeatures gameFeatures = new GameFeatures();
         WorldUpdater updater = createUpdater(gameFeatures, "frontalCollisionWithSpace");
 
@@ -141,7 +141,7 @@ public class WorldUpdaterTest {
         tiles[bot1StartPos] = new Tile(new CharacterImpl("A", "A", bot1StartPos), "A");
         tiles[bot2StartPos] = new Tile(new CharacterImpl("B", "B", bot2StartPos), "B");
 
-        WorldState start = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState start = ws.withTiles(tiles);
         GameFeatures gameFeatures = new GameFeatures();
         WorldUpdater updater = createUpdater(gameFeatures, "frontalCollisionWithSpace");
 
@@ -215,7 +215,7 @@ public class WorldUpdaterTest {
         tiles[bot3StartPos] = new Tile(new CharacterImpl("C", "C", bot3StartPos), "C");
         tiles[bot4StartPos] = new Tile(new CharacterImpl("D", "D", bot4StartPos), "D");
 
-        WorldState start = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState start = ws.withTiles(tiles);
         GameFeatures gameFeatures = new GameFeatures();
         WorldUpdater updater = createUpdater(gameFeatures, "dancingInACircle");
 
@@ -289,7 +289,7 @@ public class WorldUpdaterTest {
         tiles[bot3StartPos] = new Tile(new CharacterImpl("C", "C", bot3StartPos), "C");
         tiles[bot4StartPos] = new Tile(new CharacterImpl("D", "D", bot4StartPos), "D");
 
-        WorldState start = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState start = ws.withTiles(tiles);
         GameFeatures gameFeatures = new GameFeatures();
         WorldUpdater updater = createUpdater(gameFeatures, "chainCollision");
 
@@ -338,7 +338,7 @@ public class WorldUpdaterTest {
         tiles[bot1Pos] = new Tile(new CharacterImpl("A", "A", bot1Pos), "A");
         tiles[obstaclePos] = new Tile(new Obstacle());
 
-        WorldState start = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState start = ws.withTiles(tiles);
         GameFeatures gameFeatures = new GameFeatures();
         WorldUpdater updater = createUpdater(gameFeatures, "obstacleCollision");
 
@@ -383,7 +383,7 @@ public class WorldUpdaterTest {
         tiles[bot1Pos] = new Tile(character, "A");
         tiles[obstaclePos] = new Tile(new Obstacle());
 
-        WorldState start = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState start = ws.withTiles(tiles);
         GameFeatures gameFeatures = new GameFeatures();
         WorldUpdater updater = createUpdater(gameFeatures, "basicExplosion");
 
@@ -452,7 +452,7 @@ public class WorldUpdaterTest {
 
         tiles[obstaclePos] = new Tile(new Obstacle());
 
-        WorldState start = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState start = ws.withTiles(tiles);
         GameFeatures gameFeatures = new GameFeatures();
         WorldUpdater updater = createUpdater(gameFeatures, "crossingExplosion");
 

--- a/domain/src/main/java/se/cygni/game/WorldState.java
+++ b/domain/src/main/java/se/cygni/game/WorldState.java
@@ -262,6 +262,15 @@ public class WorldState {
     }
 
     /**
+     *
+     * @param tiles
+     * @return a new world with its tiles updated
+     */
+    public WorldState withTiles(Tile[] tiles) {
+        return new WorldState(getWidth(), getHeight(), tiles, getCollisions(), getExplosions());
+    }
+
+    /**
      * The world is represented by a single array
      */
     private Tile[] createEmptyTiles() {
@@ -284,11 +293,29 @@ public class WorldState {
         this.explosions = explosions;
     }
 
+    /**
+     *
+     * @param explosions
+     * @return a new world with its explosions updated
+     */
+    public WorldState withExplosions(Map<Integer, List<String>> explosions) {
+        return new WorldState(getWidth(), getHeight(), getTiles(), getCollisions(), explosions);
+    }
+
     public Map<Integer, List<String>> getCollisions() {
         return collisions;
     }
 
     public void setCollisions(Map<Integer, List<String>> collisions) {
         this.collisions = collisions;
+    }
+
+    /**
+     *
+     * @param collisions
+     * @return a new world with its collisions updated
+     */
+    public WorldState withCollisions(Map<Integer, List<String>> collisions) {
+        return new WorldState(getWidth(), getHeight(), getTiles(), collisions, getExplosions());
     }
 }

--- a/domain/src/main/java/se/cygni/game/testutil/PaintbotTestUtil.java
+++ b/domain/src/main/java/se/cygni/game/testutil/PaintbotTestUtil.java
@@ -23,7 +23,7 @@ public class PaintbotTestUtil {
             tiles[position] = new Tile(createWorldObject(worldType));
         });
 
-        return new WorldState(width, height, tiles);
+        return ws.withTiles(tiles);
     }
 
     public static <T extends WorldObject> T createWorldObject(Class<T> clazz) {
@@ -41,7 +41,7 @@ public class PaintbotTestUtil {
 
         Tile[] tiles = ws.getTiles();
         tiles[position] = new Tile(item);
-        return new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        return ws.withTiles(tiles);
     }
 
     public static WorldState addPaintbot(
@@ -52,7 +52,7 @@ public class PaintbotTestUtil {
         for (Character sp : characters) {
             tiles[sp.getPosition()] = new Tile(sp);
         }
-        return new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        return ws.withTiles(tiles);
     }
 
 }

--- a/domain/src/main/java/se/cygni/game/transformation/AddRandomObstacle.java
+++ b/domain/src/main/java/se/cygni/game/transformation/AddRandomObstacle.java
@@ -55,7 +55,7 @@ public class AddRandomObstacle implements WorldTransformation {
                 log.debug("Had to replace obstacle!");
         }
 
-        return new WorldState(currentWorld.getWidth(), currentWorld.getHeight(), tiles);
+        return currentWorld.withTiles(tiles);
     }
 
     private Tile[] placeObstacle(int[] positions, WorldState currentWorld) {

--- a/domain/src/main/java/se/cygni/game/transformation/AddWorldObjectAtRandomPosition.java
+++ b/domain/src/main/java/se/cygni/game/transformation/AddWorldObjectAtRandomPosition.java
@@ -50,6 +50,6 @@ public class AddWorldObjectAtRandomPosition implements WorldTransformation {
 
         tiles[randomPosition] = newTile;
 
-        return new WorldState(currentWorld.getWidth(), currentWorld.getHeight(), tiles);
+        return currentWorld.withTiles(tiles);
     }
 }

--- a/domain/src/main/java/se/cygni/game/transformation/AddWorldObjectsInCircle.java
+++ b/domain/src/main/java/se/cygni/game/transformation/AddWorldObjectsInCircle.java
@@ -71,6 +71,6 @@ public class AddWorldObjectsInCircle implements WorldTransformation {
             tiles[tileNo] = new Tile(wo);
             rotated += rotation;
         }
-        return new WorldState(width, height, tiles);
+        return currentWorld.withTiles(tiles);
     }
 }

--- a/domain/src/main/java/se/cygni/game/transformation/DecrementStun.java
+++ b/domain/src/main/java/se/cygni/game/transformation/DecrementStun.java
@@ -19,6 +19,6 @@ public class DecrementStun implements WorldTransformation {
             character.decrementStun();
         });
 
-        return new WorldState(currentWorld.getWidth(), currentWorld.getHeight(), tiles);
+        return currentWorld.withTiles(tiles);
     }
 }

--- a/domain/src/main/java/se/cygni/game/transformation/KeepOnlyObjectsOfType.java
+++ b/domain/src/main/java/se/cygni/game/transformation/KeepOnlyObjectsOfType.java
@@ -29,6 +29,6 @@ public class KeepOnlyObjectsOfType implements WorldTransformation {
                 }
         );
 
-        return new WorldState(currentWorld.getWidth(), currentWorld.getHeight(), tiles);
+        return currentWorld.withTiles(tiles);
     }
 }

--- a/domain/src/main/java/se/cygni/game/transformation/KeepOnlyPaintbotWithId.java
+++ b/domain/src/main/java/se/cygni/game/transformation/KeepOnlyPaintbotWithId.java
@@ -36,6 +36,6 @@ public class KeepOnlyPaintbotWithId implements WorldTransformation {
                 }
         );
 
-        return new WorldState(currentWorld.getWidth(), currentWorld.getHeight(), tiles);
+        return currentWorld.withTiles(tiles);
     }
 }

--- a/domain/src/main/java/se/cygni/game/transformation/RemoveRandomWorldObject.java
+++ b/domain/src/main/java/se/cygni/game/transformation/RemoveRandomWorldObject.java
@@ -31,6 +31,6 @@ public class RemoveRandomWorldObject<T extends WorldObject> implements WorldTran
         Tile currentTile = tiles[randomPosition];
         tiles[randomPosition] = new Tile(new Empty(), currentTile.getOwnerID());
 
-        return new WorldState(currentWorld.getWidth(), currentWorld.getHeight(), tiles);
+        return currentWorld.withTiles(tiles);
     }
 }

--- a/domain/src/main/java/se/cygni/game/transformation/ReplaceWorldObject.java
+++ b/domain/src/main/java/se/cygni/game/transformation/ReplaceWorldObject.java
@@ -27,6 +27,6 @@ public class ReplaceWorldObject implements WorldTransformation {
         Tile[] tiles = currentWorld.getTiles();
         tiles[position] = new Tile(worldObject);
 
-        return new WorldState(currentWorld.getWidth(), currentWorld.getHeight(), tiles);
+        return currentWorld.withTiles(tiles);
     }
 }

--- a/domain/src/test/java/se/cygni/game/WorldStateTest.java
+++ b/domain/src/test/java/se/cygni/game/WorldStateTest.java
@@ -38,7 +38,7 @@ public class WorldStateTest {
         PowerUp powerUp = new PowerUp();
         tiles[12] = new Tile(powerUp);
 
-        ws = new WorldState(10, 10, tiles);
+        ws = ws.withTiles(tiles);
 
         assertEquals(powerUp, ws.getTile(12).getContent());
     }
@@ -188,7 +188,7 @@ public class WorldStateTest {
         tiles[92] = new Tile(new Obstacle());
         tiles[98] = new Tile(new Obstacle());
 
-        WorldState newWorld = new WorldState(ws.getWidth(), ws.getHeight(), tiles);
+        WorldState newWorld = ws.withTiles(tiles);
 
         int[] foodPositions = newWorld.listPositionsWithContentOf(PowerUp.class);
         int[] obstaclePositions = newWorld.listPositionsWithContentOf(Obstacle.class);

--- a/domain/src/test/java/se/cygni/game/transformation/DecrementStunTest.java
+++ b/domain/src/test/java/se/cygni/game/transformation/DecrementStunTest.java
@@ -52,15 +52,12 @@ public class DecrementStunTest {
 
     @Test
     public void testTransformWithoutTouchingCollisionsOrExplosions() {
-        CharacterImpl paintbotA = new CharacterImpl("a", "a", 2);
-
         WorldState ws = new WorldState(3, 3);
-        Tile[] tiles = ws.getTiles();
         Map<Integer, List<String>> collisions = new HashMap<>();
         collisions.put(0, List.of("a"));
         Map<Integer, List<String>> explosions = new HashMap<>();
         explosions.put(0, List.of("a"));
-        WorldState worldState = ws.withTiles(tiles).withCollisions(collisions).withExplosions(explosions);
+        WorldState worldState = ws.withCollisions(collisions).withExplosions(explosions);
 
         DecrementStun decrementStun = new DecrementStun();
 

--- a/domain/src/test/java/se/cygni/game/transformation/DecrementStunTest.java
+++ b/domain/src/test/java/se/cygni/game/transformation/DecrementStunTest.java
@@ -22,9 +22,10 @@ public class DecrementStunTest {
         CharacterImpl paintbotA = new CharacterImpl("a", "a", 2);
         paintbotA.setIsStunnedForTicks(3);
 
-        Tile[] tiles = new WorldState(3, 3).getTiles();
+        WorldState ws = new WorldState(3, 3);
+        Tile[] tiles = ws.getTiles();
         tiles[2] = new Tile(paintbotA);
-        WorldState worldState = new WorldState(3, 3, tiles);
+        WorldState worldState = ws.withTiles(tiles);
 
         DecrementStun decrementStun = new DecrementStun();
 
@@ -37,9 +38,10 @@ public class DecrementStunTest {
     public void testTransformWithZeroCount() {
         CharacterImpl paintbotA = new CharacterImpl("a", "a", 2);
 
-        Tile[] tiles = new WorldState(3, 3).getTiles();
+        WorldState ws = new WorldState(3, 3);
+        Tile[] tiles = ws.getTiles();
         tiles[2] = new Tile(paintbotA);
-        WorldState worldState = new WorldState(3, 3, tiles);
+        WorldState worldState = ws.withTiles(tiles);
 
         DecrementStun decrementStun = new DecrementStun();
 
@@ -52,13 +54,13 @@ public class DecrementStunTest {
     public void testTransformWithoutTouchingCollisionsOrExplosions() {
         CharacterImpl paintbotA = new CharacterImpl("a", "a", 2);
 
-        Tile[] tiles = new WorldState(3, 3).getTiles();
-        tiles[2] = new Tile(paintbotA);
+        WorldState ws = new WorldState(3, 3);
+        Tile[] tiles = ws.getTiles();
         Map<Integer, List<String>> collisions = new HashMap<>();
         collisions.put(0, List.of("a"));
         Map<Integer, List<String>> explosions = new HashMap<>();
         explosions.put(0, List.of("a"));
-        WorldState worldState = new WorldState(3, 3, tiles, collisions, explosions);
+        WorldState worldState = ws.withTiles(tiles).withCollisions(collisions).withExplosions(explosions);
 
         DecrementStun decrementStun = new DecrementStun();
 

--- a/domain/src/test/java/se/cygni/game/transformation/DecrementStunTest.java
+++ b/domain/src/test/java/se/cygni/game/transformation/DecrementStunTest.java
@@ -7,6 +7,10 @@ import se.cygni.game.worldobject.CharacterImpl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * @author Alan Tibbetts
  * @since 12/04/16
@@ -42,5 +46,28 @@ public class DecrementStunTest {
         WorldState updatedWorldState = decrementStun.transform(worldState);
         CharacterImpl updatedCharacter = updatedWorldState.getCharacterById("a");
         assertEquals(0, updatedCharacter.getIsStunnedForTicks());
+    }
+
+    @Test
+    public void testTransformWithoutTouchingCollisionsOrExplosions() {
+        CharacterImpl paintbotA = new CharacterImpl("a", "a", 2);
+
+        Tile[] tiles = new WorldState(3, 3).getTiles();
+        tiles[2] = new Tile(paintbotA);
+        Map<Integer, List<String>> collisions = new HashMap<>();
+        collisions.put(0, List.of("a"));
+        Map<Integer, List<String>> explosions = new HashMap<>();
+        explosions.put(0, List.of("a"));
+        WorldState worldState = new WorldState(3, 3, tiles, collisions, explosions);
+
+        DecrementStun decrementStun = new DecrementStun();
+
+        WorldState updatedWorldState = decrementStun.transform(worldState);
+        assertEquals(1, updatedWorldState.getCollisions().size());
+        assertEquals(1, updatedWorldState.getCollisions().get(0).size());
+        assertEquals("a", updatedWorldState.getCollisions().get(0).get(0));
+        assertEquals(1, updatedWorldState.getExplosions().size());
+        assertEquals(1, updatedWorldState.getExplosions().get(0).size());
+        assertEquals("a", updatedWorldState.getExplosions().get(0).get(0));
     }
 }

--- a/domain/src/test/java/se/cygni/game/transformation/KeepOnlyPaintbotWithIdTest.java
+++ b/domain/src/test/java/se/cygni/game/transformation/KeepOnlyPaintbotWithIdTest.java
@@ -17,12 +17,13 @@ public class KeepOnlyPaintbotWithIdTest {
 
     @Test
     public void testTransformPaintbotHeadsOnly() throws TransformationException {
-        Tile[] tiles = new WorldState(3, 3).getTiles();
+        WorldState ws = new WorldState(3, 3);
+        Tile[] tiles = ws.getTiles();
         tiles[2] = new Tile(new CharacterImpl("a", "a", 2));
         tiles[6] = new Tile(new CharacterImpl("b", "b", 6));
         tiles[8] = new Tile(new CharacterImpl("b", "b", 6));
 
-        WorldState worldState = new WorldState(3, 3, tiles);
+        WorldState worldState = ws.withTiles(tiles);
 
         KeepOnlyPaintbotWithId keepOnlyPaintbotWithId = new KeepOnlyPaintbotWithId("a");
         WorldState updatedWorldState = keepOnlyPaintbotWithId.transform(worldState);
@@ -46,12 +47,13 @@ public class KeepOnlyPaintbotWithIdTest {
 
     @Test(expected = TransformationException.class)
     public void testTransformCheckingNullId() throws TransformationException {
-        Tile[] tiles = new WorldState(3, 3).getTiles();
+        WorldState ws = new WorldState(3, 3);
+        Tile[] tiles = ws.getTiles();
         tiles[2] = new Tile(new CharacterImpl("a", "a", 2));
         tiles[6] = new Tile(new CharacterImpl("b", "b", 6));
         tiles[8] = new Tile(new CharacterImpl("b", "b", 6));
 
-        WorldState worldState = new WorldState(3, 3, tiles);
+        WorldState worldState = ws.withTiles(tiles);
 
         KeepOnlyPaintbotWithId keepOnlyPaintbotWithId = new KeepOnlyPaintbotWithId(null);
         WorldState updatedWorldState = keepOnlyPaintbotWithId.transform(worldState);


### PR DESCRIPTION
Currently when updating the `WorldState`, the `collisions` and the `explosions` are reset before being transmitted to the players. This is because `DecrementStun` returns a new modified, and unfortunately incomplete, copy of the world.

This PR fixes that problem and adds a test to detect the same problem in the future. To prevent similar problems in the future, this is done by introducing a set of "with" methods (`withTiles`, `withCollisions`, and `withExplosions`). These methods return an updated copy of the world, and are easier to maintain than when adding new properties in the future.